### PR TITLE
Fix turb MPI

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -51,7 +51,7 @@ MeshBlock::Impl::Impl(MeshBlock *pmb, ParameterInput *pin) : pmy_block_(pmb) {
   ptracer = std::make_shared<Tracer>(pmb, pin);
 
   // turbulence
-  pturb = std::make_shared<TurbulenceModel>(pmb, pin);
+  // pturb = std::make_shared<KEpsilonTurbulence>(pmb, pin);
 
   // radiation
   prad = std::make_shared<Radiation>(pmb, pin);

--- a/src/snap/turbulence/turbulence_model.hpp
+++ b/src/snap/turbulence/turbulence_model.hpp
@@ -17,7 +17,7 @@ class ParameterInput;
 
 class TurbulenceModel {
  public:
-  TurbulenceModel(MeshBlock *pmb, ParameterInput *pin, int nvar = 1);
+  TurbulenceModel(MeshBlock *pmb, ParameterInput *pin, int nvar);
   virtual ~TurbulenceModel() {}
 
   // public data:


### PR DESCRIPTION
previously I allocated pturb because it should do nothing. However, it seems that the constructor initializes a persistent MPI call that may overlap with other boundary variables. That causes trouble in starting MPI. This PR fixes it.