### PR TITLE
Allowing the parallel for a more general 6*(2n)^2 blocks

### DIFF
--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -11,6 +11,7 @@
 int CubedSphere::FindBlockID(LogicalLocation const& loc) {
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  // std::cout << "loc.level=" << loc.level << ", loc.lx2=" << loc.lx2 << ", loc.lx3=" << loc.lx3 << std::endl;
 
   // Determine the block number
   int block_id;

--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -79,19 +79,20 @@ int CubedSphere::FindBlockID(LogicalLocation const& loc) {
 void CubedSphere::GetLocalIndex(int *lv2_lx2, int *lv2_lx3, int *local_lx2, int *local_lx3, int *bound_lim, LogicalLocation const& loc) {
 #ifdef USE_NBLOCKS
   // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  *bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
   // Find relative location within block
-  lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+  
+  *lv2_lx2 = loc.lx2 / (*bound_lim + 1);
+  *lv2_lx3 = loc.lx3 / (*bound_lim + 1);
+  *local_lx2 = loc.lx2 - (*lv2_lx2 * (*bound_lim + 1));
+  *local_lx3 = loc.lx3 - (*lv2_lx3 * (*bound_lim + 1));
 #else
   // Old method, suitable for 6*4^n blocks
-  bound_lim = (1 << (loc.level - 2)) - 1;
+  *bound_lim = (1 << (loc.level - 2)) - 1;
     // Find relative location within block
-  lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
+  *lv2_lx2 = loc.lx2 >> (loc.level - 2);
+  *lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  *local_lx2 = loc.lx2 - (*lv2_lx2 << (loc.level - 2));
+  *local_lx3 = loc.lx3 - (*lv2_lx3 << (loc.level - 2));
 #endif
 }

--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -9,8 +9,20 @@
 #include "cubed_sphere.hpp"
 
 int CubedSphere::FindBlockID(LogicalLocation const& loc) {
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+
+#ifdef NBLOCKS
+    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+    int bound_lim = (int)(sqrt(NBLOCKS / 6) + 0.5);
+    // Sanity check of NBLOCKS
+    static_assert(NBLOCKS == 6 * bound_lim * bound_lim,
+                  "NBLOCKS must be 6*(2n)^2 for the cubed sphere.");
+#else
+    // Old method, suitable for 6*4^n blocks
+    int bound_lim = (1 << (loc.level - 2));
+#endif
+  // Infer the location in the 2*3 configuration
+  int lv2_lx2 = loc.lx2 / bound_lim;
+  int lv2_lx3 = loc.lx3 / bound_lim;
   // std::cout << "loc.level=" << loc.level << ", loc.lx2=" << loc.lx2 << ", loc.lx3=" << loc.lx3 << std::endl;
 
   // Determine the block number

--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -43,6 +43,7 @@ int CubedSphere::FindBlockID(LogicalLocation const& loc) {
           std::stringstream msg;
           msg << "Error: something wrong, check the geometry setup of the "
                  "cubed sphere. \n";
+          msg << "lv2_lx2: " << lv2_lx2 << " lv2_lx3: " << lv2_lx3 << "bound_lim: " << bound_lim << "loc.lx2: " << loc.lx2 << "loc.lx3: " << loc.lx3 << std::endl;
           msg << "----------------------------------" << std::endl;
           ATHENA_ERROR(msg);
       }

--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -10,20 +10,23 @@
 
 int CubedSphere::FindBlockID(LogicalLocation const& loc) {
 
-#ifdef NBLOCKS
+#ifdef USE_NBLOCKS
     // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-    int bound_lim = (int)(sqrt(NBLOCKS / 6) + 0.5);
-    // Sanity check of NBLOCKS
-    static_assert(NBLOCKS == 6 * bound_lim * bound_lim,
-                  "NBLOCKS must be 6*(2n)^2 for the cubed sphere.");
+    int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+    // Find relative location within block
+    int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+    int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+    int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+    int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
 #else
     // Old method, suitable for 6*4^n blocks
-    int bound_lim = (1 << (loc.level - 2));
+    int bound_lim = (1 << (loc.level - 2)) - 1;
+      // Find relative location within block
+    int lv2_lx2 = loc.lx2 >> (loc.level - 2);
+    int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+    int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
+    int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
 #endif
-  // Infer the location in the 2*3 configuration
-  int lv2_lx2 = loc.lx2 / bound_lim;
-  int lv2_lx3 = loc.lx3 / bound_lim;
-  // std::cout << "loc.level=" << loc.level << ", loc.lx2=" << loc.lx2 << ", loc.lx3=" << loc.lx3 << std::endl;
 
   // Determine the block number
   int block_id;

--- a/src/exo3/cs_find_block_id.cpp
+++ b/src/exo3/cs_find_block_id.cpp
@@ -10,23 +10,8 @@
 
 int CubedSphere::FindBlockID(LogicalLocation const& loc) {
 
-#ifdef USE_NBLOCKS
-    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-    int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-    // Find relative location within block
-    int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-    int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-    int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-    int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-    // Old method, suitable for 6*4^n blocks
-    int bound_lim = (1 << (loc.level - 2)) - 1;
-      // Find relative location within block
-    int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-    int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-    int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-    int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   // Determine the block number
   int block_id;
@@ -89,4 +74,24 @@ int CubedSphere::FindBlockID(LogicalLocation const& loc) {
   }
 
   return block_id;
+}
+
+void CubedSphere::GetLocalIndex(int *lv2_lx2, int *lv2_lx3, int *local_lx2, int *local_lx3, int *bound_lim, LogicalLocation const& loc) {
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
+  lv2_lx2 = loc.lx2 >> (loc.level - 2);
+  lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
+  local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
+#endif
 }

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -15,8 +15,7 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
   if (CubedSphere::total_blocks_ == 0) {
     // Old method, suitable for 6*4^n blocks
     int bound_lim = (1 << (loc.level - 2)) - 1;
-  }
-  if (CubedSphere::total_blocks_ != total_blocks) {
+  }else{
     // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
     int bound_lim = (int)(sqrt(total_blocks / 6) - 0.5);
   }

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -12,23 +12,9 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
                               LogicalLocation const &loc) {
   // Find the block ID
   int block_id = FindBlockID(loc);
-#ifdef USE_NBLOCKS
-    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-    int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-    // Find relative location within block
-    int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-    int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-    int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-    int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-    // Old method, suitable for 6*4^n blocks
-    int bound_lim = (1 << (loc.level - 2)) - 1;
-      // Find relative location within block
-    int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-    int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-    int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-    int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+
 
   // Hard code the cases... 
   // The corner cases are not used, abandoned after reading buffers.

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -9,19 +9,30 @@
 #include "cubed_sphere.hpp"
 
 void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
-                              LogicalLocation const &loc) {
+                              LogicalLocation const &loc, int total_blocks) {
   // Find the block ID
   int block_id = FindBlockID(loc);
+  if (CubedSphere::total_blocks_ == 0) {
+    CubedSphere::total_blocks_ = total_blocks;
+    std::cout << "Total Blocks Set: " << total_blocks << std::endl;
+  }
+  if (CubedSphere::total_blocks_ != total_blocks) {
+    std::stringstream msg;
+    msg << "Error: total_blocks is not consistent. \n";
+    msg << "----------------------------------" << std::endl;
+    ATHENA_ERROR(msg);
+  }
 
   // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
+  int bound_lim = (int)(sqrt(total_blocks / 6) - 0.5);
+  // int bound_lim = (1 << (loc.level - 2)) - 1;
 
-  // Hard code the cases...
-  // No need to consider the corner cases, abandon in reading buffers.
+  // Hard code the cases... 
+  // The corner cases are not used, abandoned after reading buffers.
   int target_block = -1;           // Block id of target
   int target_loc_2, target_loc_3;  // local x2 and x3 in target block
 
@@ -168,6 +179,7 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
       std::stringstream msg;
       msg << "Error: something wrong, check the geometry setup of the cubed "
              "sphere. \n";
+      msg << "Block ID: " << block_id << std::endl;
       msg << "----------------------------------" << std::endl;
       ATHENA_ERROR(msg);
   }

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -221,8 +221,13 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
         msg << "----------------------------------" << std::endl;
         ATHENA_ERROR(msg);
     }
+#ifdef USE_NBLOCKS
+    lx3_0 = (lx3_0 * (bound_lim + 1));
+    lx2_0 = (lx2_0 * (bound_lim + 1));
+#else
     lx3_0 = (lx3_0 << (loc.level - 2));
     lx2_0 = (lx2_0 << (loc.level - 2));
+#endif
     // Add up first block and local positions
     int lx3_t = lx3_0 + target_loc_3;
     int lx2_t = lx2_0 + target_loc_2;

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -12,22 +12,23 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
                               LogicalLocation const &loc) {
   // Find the block ID
   int block_id = FindBlockID(loc);
-#ifdef NBLOCKS
+#ifdef USE_NBLOCKS
     // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
     int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-    // Sanity check of NBLOCKS
-    static_assert(NBLOCKS == 6 * bound_lim * bound_lim,
-                  "NBLOCKS must be 6*(2n)^2 for the cubed sphere.");
+    // Find relative location within block
+    int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+    int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+    int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+    int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
 #else
     // Old method, suitable for 6*4^n blocks
     int bound_lim = (1 << (loc.level - 2)) - 1;
+      // Find relative location within block
+    int lv2_lx2 = loc.lx2 >> (loc.level - 2);
+    int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+    int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
+    int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
 #endif
-
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
 
   // Hard code the cases... 
   // The corner cases are not used, abandoned after reading buffers.

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -9,18 +9,16 @@
 #include "cubed_sphere.hpp"
 
 void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
-                              LogicalLocation const &loc, int total_blocks) {
+                              LogicalLocation const &loc) {
   // Find the block ID
   int block_id = FindBlockID(loc);
   if (CubedSphere::total_blocks_ == 0) {
-    CubedSphere::total_blocks_ = total_blocks;
-    std::cout << "Total Blocks Set: " << total_blocks << std::endl;
+    // Old method, suitable for 6*4^n blocks
+    int bound_lim = (1 << (loc.level - 2)) - 1;
   }
   if (CubedSphere::total_blocks_ != total_blocks) {
-    std::stringstream msg;
-    msg << "Error: total_blocks is not consistent. \n";
-    msg << "----------------------------------" << std::endl;
-    ATHENA_ERROR(msg);
+    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+    int bound_lim = (int)(sqrt(total_blocks / 6) - 0.5);
   }
 
   // Find relative location within block
@@ -28,8 +26,6 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (int)(sqrt(total_blocks / 6) - 0.5);
-  // int bound_lim = (1 << (loc.level - 2)) - 1;
 
   // Hard code the cases... 
   // The corner cases are not used, abandoned after reading buffers.

--- a/src/exo3/cs_transform_ox.cpp
+++ b/src/exo3/cs_transform_ox.cpp
@@ -12,13 +12,16 @@ void CubedSphere::TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
                               LogicalLocation const &loc) {
   // Find the block ID
   int block_id = FindBlockID(loc);
-  if (CubedSphere::total_blocks_ == 0) {
+#ifdef NBLOCKS
+    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+    int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+    // Sanity check of NBLOCKS
+    static_assert(NBLOCKS == 6 * bound_lim * bound_lim,
+                  "NBLOCKS must be 6*(2n)^2 for the cubed sphere.");
+#else
     // Old method, suitable for 6*4^n blocks
     int bound_lim = (1 << (loc.level - 2)) - 1;
-  }else{
-    // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-    int bound_lim = (int)(sqrt(total_blocks / 6) - 0.5);
-  }
+#endif
 
   // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);

--- a/src/exo3/cubed_sphere.cpp
+++ b/src/exo3/cubed_sphere.cpp
@@ -39,17 +39,8 @@ CubedSphere::CubedSphere(MeshBlock *pmb) : pmy_block_(pmb) {
 
 Real CubedSphere::GenerateMeshX2(Real x, LogicalLocation const &loc) {
   Real x_l, x_u;
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   switch (lv2_lx2) {
     case 0:
@@ -66,17 +57,8 @@ Real CubedSphere::GenerateMeshX2(Real x, LogicalLocation const &loc) {
 
 Real CubedSphere::GenerateMeshX3(Real x, LogicalLocation const &loc) {
   Real x_l, x_u;
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   switch (lv2_lx3) {
     case 0:
@@ -101,25 +83,7 @@ Real CubedSphere::GenerateMeshX3(Real x, LogicalLocation const &loc) {
 void CubedSphere::GetLatLon(Real *lat, Real *lon, int k, int j, int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   // Calculate the needed parameters
   Real dX = tan(pcoord->x2v(j));
@@ -135,25 +99,7 @@ void CubedSphere::GetLatLonFace2(Real *lat, Real *lon, int k, int j,
                                  int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   // Calculate the needed parameters
   Real dX = tan(pcoord->x2f(j));
@@ -169,21 +115,7 @@ void CubedSphere::GetLatLonFace3(Real *lat, Real *lon, int k, int j,
                                  int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pcoord->pmy_block->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   // Calculate the needed parameters
   Real dX = tan(pcoord->x2v(j));
@@ -198,21 +130,7 @@ void CubedSphere::GetUV(Real *U, Real *V, Real V2, Real V3, int k, int j,
                         int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   Real X = tan(pcoord->x2v(j));
   Real Y = tan(pcoord->x3v(k));
@@ -226,21 +144,7 @@ void CubedSphere::GetVyVz(Real *V2, Real *V3, Real U, Real V, int k, int j,
                           int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   // Calculate the needed parameters
   Real X = tan(pcoord->x2v(j));
@@ -253,21 +157,7 @@ void CubedSphere::CalculateCoriolisForce2(int i2, int i3, Real v2, Real v3,
                                           Real *cF3) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif  
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   Real x = tan(pcoord->x2v(i2));
   Real y = tan(pcoord->x3v(i3));
@@ -298,21 +188,7 @@ void CubedSphere::CalculateCoriolisForce3(int i2, int i3, Real v1, Real v2,
                                           Real *cF3) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int blockID = FindBlockID(loc);
 
   Real x = tan(pcoord->x2v(i2));
   Real y = tan(pcoord->x3v(i3));
@@ -439,25 +315,9 @@ void CubedSphere::sendNeighborBlocks(int ox2, int ox3, int tg_rank,
                                      int tg_gid) {
   MeshBlock *pmb = pmy_block_;
   auto &loc = pmb->loc;
-
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+  int blockID = FindBlockID(loc);
   // Calculate local ID
   int tox2, tox3;
   int DirTag, DirNum, ownTag;  // Tag for target, and the numbering of axis
@@ -715,25 +575,10 @@ void CubedSphere::recvNeighborBlocks(int ox2, int ox3, int tg_rank,
   MeshBlock *pmb = pmy_block_;
   auto &loc = pmb->loc;
 
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
   int blockID = FindBlockID(loc);
-  // Calculate local ID
+
   int tox2, tox3;
   int DirTag, DirNum, ownTag;  // Tag for receiving, and the numbering of axis
                                // to place the values

--- a/src/exo3/cubed_sphere.cpp
+++ b/src/exo3/cubed_sphere.cpp
@@ -715,13 +715,25 @@ void CubedSphere::recvNeighborBlocks(int ox2, int ox3, int tg_rank,
   MeshBlock *pmb = pmy_block_;
   auto &loc = pmb->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int blockID = FindBlockID(loc);
-  // Calculate local ID
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
+#endif
+  int blockID = FindBlockID(loc);
+  // Calculate local ID
   int tox2, tox3;
   int DirTag, DirNum, ownTag;  // Tag for receiving, and the numbering of axis
                                // to place the values

--- a/src/exo3/cubed_sphere.cpp
+++ b/src/exo3/cubed_sphere.cpp
@@ -39,9 +39,19 @@ CubedSphere::CubedSphere(MeshBlock *pmb) : pmy_block_(pmb) {
 
 Real CubedSphere::GenerateMeshX2(Real x, LogicalLocation const &loc) {
   Real x_l, x_u;
-  int lx2_lv2 = loc.lx2 >> (loc.level - 2);
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
+  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
+#endif
 
-  switch (lx2_lv2) {
+  switch (lv2_lx2) {
     case 0:
       x_l = -0.5;
       x_u = 0.0;
@@ -56,9 +66,19 @@ Real CubedSphere::GenerateMeshX2(Real x, LogicalLocation const &loc) {
 
 Real CubedSphere::GenerateMeshX3(Real x, LogicalLocation const &loc) {
   Real x_l, x_u;
-  int lx3_lv2 = loc.lx3 >> (loc.level - 2);
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
+  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif
 
-  switch (lx3_lv2) {
+  switch (lv2_lx3) {
     case 0:
       x_l = -0.5;
       x_u = -1.0 / 6.0;
@@ -82,9 +102,25 @@ void CubedSphere::GetLatLon(Real *lat, Real *lon, int k, int j, int i) const {
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
+  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+
   // Calculate the needed parameters
   Real dX = tan(pcoord->x2v(j));
   Real dY = tan(pcoord->x3v(k));
@@ -100,8 +136,23 @@ void CubedSphere::GetLatLonFace2(Real *lat, Real *lon, int k, int j,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
+  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   // Calculate the needed parameters
@@ -119,8 +170,19 @@ void CubedSphere::GetLatLonFace3(Real *lat, Real *lon, int k, int j,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pcoord->pmy_block->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   // Calculate the needed parameters
@@ -137,8 +199,19 @@ void CubedSphere::GetUV(Real *U, Real *V, Real V2, Real V3, int k, int j,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   Real X = tan(pcoord->x2v(j));
@@ -154,8 +227,19 @@ void CubedSphere::GetVyVz(Real *V2, Real *V3, Real U, Real V, int k, int j,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   // Calculate the needed parameters
@@ -170,8 +254,19 @@ void CubedSphere::CalculateCoriolisForce2(int i2, int i3, Real v2, Real v3,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif  
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   Real x = tan(pcoord->x2v(i2));
@@ -204,8 +299,19 @@ void CubedSphere::CalculateCoriolisForce3(int i2, int i3, Real v1, Real v2,
   auto pcoord = pmy_block_->pcoord;
   auto &loc = pmy_block_->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+#endif
   int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
 
   Real x = tan(pcoord->x2v(i2));
@@ -334,13 +440,25 @@ void CubedSphere::sendNeighborBlocks(int ox2, int ox3, int tg_rank,
   MeshBlock *pmb = pmy_block_;
   auto &loc = pmb->loc;
 
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
-  // Calculate local ID
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
+#endif
+  int blockID = lv2_lx2 + lv2_lx3 * 2 + 1;
+  // Calculate local ID
   int tox2, tox3;
   int DirTag, DirNum, ownTag;  // Tag for target, and the numbering of axis
   int ox2_bkp = ox2;
@@ -560,6 +678,16 @@ void CubedSphere::sendNeighborBlocks(int ox2, int ox3, int tg_rank,
   }
 
   // Calculate the tag of destination
+#ifdef USE_NBLOCKS
+  if (tox2 == -1)
+    DirTag = 0 + 4 * pmb->gid + 24 * (bound_lim + 1) * tg_gid;
+  if (tox2 == 1)
+    DirTag = 1 + 4 * pmb->gid + 24 * (bound_lim + 1) * tg_gid;
+  if (tox3 == -1)
+    DirTag = 2 + 4 * pmb->gid + 24 * (bound_lim + 1) * tg_gid;
+  if (tox3 == 1)
+    DirTag = 3 + 4 * pmb->gid + 24 * (bound_lim + 1) * tg_gid;
+#else
   if (tox2 == -1)
     DirTag = 0 + 4 * pmb->gid + 24 * (1 << (loc.level - 2)) * tg_gid;
   if (tox2 == 1)
@@ -568,6 +696,7 @@ void CubedSphere::sendNeighborBlocks(int ox2, int ox3, int tg_rank,
     DirTag = 2 + 4 * pmb->gid + 24 * (1 << (loc.level - 2)) * tg_gid;
   if (tox3 == 1)
     DirTag = 3 + 4 * pmb->gid + 24 * (1 << (loc.level - 2)) * tg_gid;
+#endif
   // Send by MPI: we don't care whether it is in the same process for now
   if (ox2 == -1) ownTag = 0;
   if (ox2 == 1) ownTag = 1;
@@ -658,6 +787,16 @@ void CubedSphere::recvNeighborBlocks(int ox2, int ox3, int tg_rank,
   int dsize = ((kb2 - kb1 + 1) * (jb2 - jb1 + 1) * (ib2 - ib1 + 1) * NWAVE);
   Real *data = new Real[dsize];
   // Calculate the tag for receiving
+#ifdef USE_NBLOCKS
+  if (ox2 == -1)
+    DirTag = 0 + 4 * tg_gid + 24 * (bound_lim + 1) * pmb->gid;
+  if (ox2 == 1)
+    DirTag = 1 + 4 * tg_gid + 24 * (bound_lim + 1) * pmb->gid;
+  if (ox3 == -1)
+    DirTag = 2 + 4 * tg_gid + 24 * (bound_lim + 1) * pmb->gid;
+  if (ox3 == 1)
+    DirTag = 3 + 4 * tg_gid + 24 * (bound_lim + 1) * pmb->gid;
+#else
   if (ox2 == -1)
     DirTag = 0 + 4 * tg_gid + 24 * (1 << (loc.level - 2)) * pmb->gid;
   if (ox2 == 1)
@@ -666,6 +805,7 @@ void CubedSphere::recvNeighborBlocks(int ox2, int ox3, int tg_rank,
     DirTag = 2 + 4 * tg_gid + 24 * (1 << (loc.level - 2)) * pmb->gid;
   if (ox3 == 1)
     DirTag = 3 + 4 * tg_gid + 24 * (1 << (loc.level - 2)) * pmb->gid;
+#endif
 
 #ifdef MPI_PARALLEL
   MPI_Recv(data, dsize, MPI_DOUBLE, tg_rank, DirTag, MPI_COMM_WORLD,

--- a/src/exo3/cubed_sphere.hpp
+++ b/src/exo3/cubed_sphere.hpp
@@ -66,11 +66,6 @@ class CubedSphere {
 #endif
 
   std::vector<Real> LRDataBuffer[4];
-#ifdef NBLOCKS
-  int total_blocks_ = NBLOCKS;
-#else
-  int total_blocks_ = 0;
-#endif
   MeshBlock *pmy_block_;
 };
 

--- a/src/exo3/cubed_sphere.hpp
+++ b/src/exo3/cubed_sphere.hpp
@@ -18,7 +18,7 @@ class CubedSphere {
 
   static int FindBlockID(LogicalLocation const &loc);
   static void TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
-                          LogicalLocation const &loc);
+                          LogicalLocation const &loc, int total_blocks);
 
   static Real GenerateMeshX2(Real x, LogicalLocation const &loc);
   static Real GenerateMeshX3(Real x, LogicalLocation const &loc);
@@ -41,7 +41,7 @@ class CubedSphere {
                                       Real *v2c, Real *v3c) const;
 
   void TransformOX(int *ox2, int *ox3, int *tox2, int *tox3) const {
-    return TransformOX(ox2, ox3, tox2, tox3, pmy_block_->loc);
+    return TransformOX(ox2, ox3, tox2, tox3, pmy_block_->loc, total_blocks_);
   }
 
   void SaveLR3DValues(AthenaArray<Real> &L_in, AthenaArray<Real> &R_in,
@@ -66,7 +66,7 @@ class CubedSphere {
 #endif
 
   std::vector<Real> LRDataBuffer[4];
-
+  int total_blocks_ = 0;
   MeshBlock *pmy_block_;
 };
 

--- a/src/exo3/cubed_sphere.hpp
+++ b/src/exo3/cubed_sphere.hpp
@@ -17,6 +17,9 @@ class CubedSphere {
   ~CubedSphere() {}
 
   static int FindBlockID(LogicalLocation const &loc);
+  static void GetLocalIndex(int *lv2_lx2, int *lv2_lx3, int *local_lx2,
+                            int *local_lx3, int *bound_lim,
+                            LogicalLocation const &loc);
   static void TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
                           LogicalLocation const &loc);
 

--- a/src/exo3/cubed_sphere.hpp
+++ b/src/exo3/cubed_sphere.hpp
@@ -18,7 +18,7 @@ class CubedSphere {
 
   static int FindBlockID(LogicalLocation const &loc);
   static void TransformOX(int *ox2, int *ox3, int *tox2, int *tox3,
-                          LogicalLocation const &loc, int total_blocks);
+                          LogicalLocation const &loc);
 
   static Real GenerateMeshX2(Real x, LogicalLocation const &loc);
   static Real GenerateMeshX3(Real x, LogicalLocation const &loc);
@@ -41,7 +41,7 @@ class CubedSphere {
                                       Real *v2c, Real *v3c) const;
 
   void TransformOX(int *ox2, int *ox3, int *tox2, int *tox3) const {
-    return TransformOX(ox2, ox3, tox2, tox3, pmy_block_->loc, total_blocks_);
+    return TransformOX(ox2, ox3, tox2, tox3, pmy_block_->loc);
   }
 
   void SaveLR3DValues(AthenaArray<Real> &L_in, AthenaArray<Real> &R_in,
@@ -66,7 +66,11 @@ class CubedSphere {
 #endif
 
   std::vector<Real> LRDataBuffer[4];
+#ifdef NBLOCKS
+  int total_blocks_ = NBLOCKS;
+#else
   int total_blocks_ = 0;
+#endif
   MeshBlock *pmy_block_;
 };
 

--- a/src/exo3/cubed_sphere_utility.cpp
+++ b/src/exo3/cubed_sphere_utility.cpp
@@ -103,7 +103,7 @@ void InteprolateX2(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
   // Interpolation along X2 (j) axis, used before sending data to X3 (k) axis
   // Get the local indices
   int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
-  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+  CubedSphere::GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   int meshblock_size = ej - sj + 1;
   int N_blk = meshblock_size *
@@ -233,7 +233,7 @@ void InteprolateX3(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
   // Interpolation along X3 (k) axis, used before sending data to ghost zone in
   // X2 (j) direction Get the local indices
   int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
-  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+  CubedSphere::GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   int meshblock_size = ek - sk + 1;
   int N_blk = meshblock_size *
@@ -402,7 +402,7 @@ void PackData(const AthenaArray<Real> &src, Real *buf, int sn, int en, int si,
 
   // Get the local indices
   int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
-  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+  CubedSphere::GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
 
   // Work on interpolation
   AthenaArray<Real> interpolatedSrc;

--- a/src/exo3/cubed_sphere_utility.cpp
+++ b/src/exo3/cubed_sphere_utility.cpp
@@ -429,12 +429,23 @@ void PackData(const AthenaArray<Real> &src, Real *buf, int sn, int en, int si,
   }
 
   // Get the local indices
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-
+#endif
   // Work on interpolation
   AthenaArray<Real> interpolatedSrc;
   interpolatedSrc.NewAthenaArray(en - sn + 1, ek - sk + 1, ej - sj + 1,

--- a/src/exo3/cubed_sphere_utility.cpp
+++ b/src/exo3/cubed_sphere_utility.cpp
@@ -102,23 +102,9 @@ void InteprolateX2(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
                    int sk, int ek, int TypeFlag) {
   // Interpolation along X2 (j) axis, used before sending data to X3 (k) axis
   // Get the local indices
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+
   int meshblock_size = ej - sj + 1;
   int N_blk = meshblock_size *
               (bound_lim + 1);  // N in X2 direction for each panel. This value
@@ -246,23 +232,9 @@ void InteprolateX3(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
                    int sk, int ek, int TypeFlag) {
   // Interpolation along X3 (k) axis, used before sending data to ghost zone in
   // X2 (j) direction Get the local indices
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+
   int meshblock_size = ek - sk + 1;
   int N_blk = meshblock_size *
               (bound_lim + 1);  // N in X2 direction for each panel. This value
@@ -429,23 +401,9 @@ void PackData(const AthenaArray<Real> &src, Real *buf, int sn, int en, int si,
   }
 
   // Get the local indices
-#ifdef USE_NBLOCKS
-  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
-  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
-  // Find relative location within block
-  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
-  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
-  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
-  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
-#else
-  // Old method, suitable for 6*4^n blocks
-  int bound_lim = (1 << (loc.level - 2)) - 1;
-    // Find relative location within block
-  int lv2_lx2 = loc.lx2 >> (loc.level - 2);
-  int lv2_lx3 = loc.lx3 >> (loc.level - 2);
-  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-#endif
+  int lv2_lx2, lv2_lx3, local_lx2, local_lx3, bound_lim;
+  GetLocalIndex(&lv2_lx2, &lv2_lx3, &local_lx2, &local_lx3, &bound_lim, loc);
+
   // Work on interpolation
   AthenaArray<Real> interpolatedSrc;
   interpolatedSrc.NewAthenaArray(en - sn + 1, ek - sk + 1, ej - sj + 1,

--- a/src/exo3/cubed_sphere_utility.cpp
+++ b/src/exo3/cubed_sphere_utility.cpp
@@ -102,10 +102,23 @@ void InteprolateX2(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
                    int sk, int ek, int TypeFlag) {
   // Interpolation along X2 (j) axis, used before sending data to X3 (k) axis
   // Get the local indices
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
   int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
+  int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
+#endif
   int meshblock_size = ej - sj + 1;
   int N_blk = meshblock_size *
               (bound_lim + 1);  // N in X2 direction for each panel. This value
@@ -233,10 +246,23 @@ void InteprolateX3(const AthenaArray<Real> &src, AthenaArray<Real> &tgt,
                    int sk, int ek, int TypeFlag) {
   // Interpolation along X3 (k) axis, used before sending data to ghost zone in
   // X2 (j) direction Get the local indices
+#ifdef USE_NBLOCKS
+  // Updated method, need to manually setup in configure.hpp, allow 6*n^2 blocks
+  int bound_lim = (int)(sqrt(NBLOCKS / 6) - 0.5);
+  // Find relative location within block
+  int lv2_lx2 = loc.lx2 / (bound_lim + 1);
+  int lv2_lx3 = loc.lx3 / (bound_lim + 1);
+  int local_lx2 = loc.lx2 - (lv2_lx2 * (bound_lim + 1));
+  int local_lx3 = loc.lx3 - (lv2_lx3 * (bound_lim + 1));
+#else
+  // Old method, suitable for 6*4^n blocks
+  int bound_lim = (1 << (loc.level - 2)) - 1;
+    // Find relative location within block
   int lv2_lx2 = loc.lx2 >> (loc.level - 2);
   int lv2_lx3 = loc.lx3 >> (loc.level - 2);
+  int local_lx2 = loc.lx2 - (lv2_lx2 << (loc.level - 2));
   int local_lx3 = loc.lx3 - (lv2_lx3 << (loc.level - 2));
-  int bound_lim = (1 << (loc.level - 2)) - 1;
+#endif
   int meshblock_size = ek - sk + 1;
   int N_blk = meshblock_size *
               (bound_lim + 1);  // N in X2 direction for each panel. This value


### PR DESCRIPTION
Allowing a more general 6*(2n)^2 blocks parallel
Currently still a backdoor solution:

- Need to add `#define USE_NBLOCKS` and `NBLOCKS=600` in configure.hpp
- Change configure.hpp before making
- Originally allowed configurations are 6*2^(2n), not changed if the backdoor change is not taken